### PR TITLE
simple_test.pyのエラーを回避する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN ./waf configure --enable-examples && ./waf build
 
 # Install ns3gym
 RUN pip install --user ./src/opengym/model/ns3gym
+RUN pip install -U protobuf~=3.20.0
 
 # Run ns3gym
 CMD ["python", "./scratch/opengym/simple_test.py"]

--- a/scratch/opengym/simple_test.py
+++ b/scratch/opengym/simple_test.py
@@ -11,7 +11,7 @@ __version__ = "0.1.0"
 __email__ = "gawlowicz@tkn.tu-berlin.de"
 
 
-env = gym.make('ns3-v0')
+env = ns3env.Ns3Env()
 env.reset()
 
 ob_space = env.observation_space


### PR DESCRIPTION
現状だと `simple_test.py` を実行するとエラーで失敗するかと思います。
これを回避するため下記のようにします

* protobuf のバージョンを下げる
* `ns3env.Ns3Env()` を使う
  * 参考: https://github.com/tsukuba-websci/ns3-gym/blob/b9f8803ed6264bdf142e7ecc0e41cd2477256dc0/README.md?plain=1#L74-L75