### PR TITLE
Feature: docker buildの開発者体験をいい感じにする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# documentation
+docs/
+doc/
+*.txt
+*.md
+*.html
+
+# other documentation
+AUTHORS
+CHANGES.html
+LICENSE
+RELEASE_NOTES
+VERSION
+
+# log files
+*.log
+*.out
+
+CHANGELOG.html
+VERSION
+RELEASE_NOTES
+
+# dotfiles
+.*
+
+# Others
+.git/
+.gitignore
+.gitmodules

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,14 +10,12 @@ AUTHORS
 CHANGES.html
 LICENSE
 RELEASE_NOTES
-VERSION
 
 # log files
 *.log
 *.out
 
 CHANGELOG.html
-VERSION
 RELEASE_NOTES
 
 # dotfiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:20.04
 
 # Install Install all required dependencies required by ns-3
-RUN apt-get update && apt-get install -y gcc g++ python3-pip python git
+RUN apt-get update && apt-get install -y gcc g++ python3-pip python git && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ZMQ and Protocol Buffers libs
-RUN apt-get update && apt-get install -y libzmq5 libzmq3-dev libprotobuf-dev protobuf-compiler
+RUN apt-get update && apt-get install -y libzmq5 libzmq3-dev libprotobuf-dev protobuf-compiler && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# clone ns3-gym repo
-RUN git clone --depth 1 https://github.com/tsukuba-websci/ns3-gym.git
+# COPY ns3-gym
+COPY . /ns3-gym
 
 # Change WORKDIR
 WORKDIR /ns3-gym

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 # Install Install all required dependencies required by ns-3
-RUN apt-get update && apt-get install -y gcc g++ python3-pip python git && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y gcc g++ python3-pip python && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install ZMQ and Protocol Buffers libs
 RUN apt-get update && apt-get install -y libzmq5 libzmq3-dev libprotobuf-dev protobuf-compiler && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
ref. #6 

## WHY

現在のDockerfileにはいくつかの問題があった．

1. ソースを `git clone ...` で持ってきていた
2. プロジェクトのルート以下の任意のファイルを変更するたびに，ns3の重いbuildが走っていた

これらの問題に対処し，同時にdocker buildの実行時間を早くしたい（ついでにイメージの縮小化もできると...嬉しい!!）

## WHAT

1.  `COPY . /ns3-gym` によるコピーに変更する（ #5 ではすでに入っている）
2. `.dockerignore` を追加し，不要なファイルをコンテナに載せないようにする
3. `apt-get clean` を追加し，イメージの縮小か 

## Other

`/scratch/rl-tcp/*.py`  を `docker run` 時にマウントしてもうまく動くならそう変更したい（COPYの対象から外すことができ，`docker build` 時にcacheが効きやすくなるので）